### PR TITLE
App can now set the media stream volume before playback

### DIFF
--- a/app/src/main/java/in/basulabs/mahalaya/AudioFocusManager.java
+++ b/app/src/main/java/in/basulabs/mahalaya/AudioFocusManager.java
@@ -40,6 +40,7 @@ final class AudioFocusManager implements AudioManager.OnAudioFocusChangeListener
 
 	/**
 	 * Main constructor.
+	 *
 	 * @param context The Context which wants to me to manage audio focus.
 	 */
 	AudioFocusManager(Context context) {
@@ -71,7 +72,7 @@ final class AudioFocusManager implements AudioManager.OnAudioFocusChangeListener
 
 			return audioManager.requestAudioFocus(audioFocusRequest);
 		} else {
-			return audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC,AudioManager.AUDIOFOCUS_GAIN);
+			return audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
 		}
 
 	}
@@ -86,7 +87,6 @@ final class AudioFocusManager implements AudioManager.OnAudioFocusChangeListener
 			switch (focusChange) {
 
 				case AudioManager.AUDIOFOCUS_GAIN:
-					//Log.e(this.getClass().toString(), "Focus gained. Starting player...");
 
 					focusAbandoned = false;
 					restartPlayer();
@@ -99,17 +99,14 @@ final class AudioFocusManager implements AudioManager.OnAudioFocusChangeListener
 					break;
 
 				case AudioManager.AUDIOFOCUS_LOSS:
-					//Log.e(this.getClass().toString(), "Focus lost. Player paused.");
 					pausePlayer(true);
 					break;
 
 				case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-					//Log.e(this.getClass().toString(), "Focus loss transient. Player paused.");
 					pausePlayer(false);
 					break;
 
 				case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-					//Log.e(this.getClass().toString(), "Focus loss transient. Player ducked.");
 
 					// Decrease volume:
 					Intent intent3 = new Intent(Constants.ACTION_DECREASE_VOLUME);
@@ -132,7 +129,6 @@ final class AudioFocusManager implements AudioManager.OnAudioFocusChangeListener
 			audioManager.abandonAudioFocus(this);
 		}
 		focusAbandoned = true;
-		//Log.e(this.getClass().toString(), "Focus abandoned.");
 	}
 
 	//------------------------------------------------------------------------------------------
@@ -143,7 +139,6 @@ final class AudioFocusManager implements AudioManager.OnAudioFocusChangeListener
 	 * @param abandonFocus Whether focus should be abandoned. Sent as {@link Constants#EXTRA_ABANDON_FOCUS}.
 	 */
 	private void pausePlayer(boolean abandonFocus) {
-		//Log.e(this.getClass().toString(), "Requesting player to be paused...");
 		Intent intent = new Intent(Constants.ACTION_PAUSE_PLAYER);
 		intent.putExtra(Constants.EXTRA_ABANDON_FOCUS, abandonFocus);
 		context.sendBroadcast(intent);
@@ -155,7 +150,6 @@ final class AudioFocusManager implements AudioManager.OnAudioFocusChangeListener
 	 * (Re)starts the media playback by sending the {@link Constants#ACTION_START_PLAYER} broadcast.
 	 */
 	private void restartPlayer() {
-		//Log.e(this.getClass().toString(), "Requesting player to be restarted...");
 		Intent intent = new Intent(Constants.ACTION_START_PLAYER);
 		context.sendBroadcast(intent);
 	}

--- a/app/src/main/java/in/basulabs/mahalaya/Constants.java
+++ b/app/src/main/java/in/basulabs/mahalaya/Constants.java
@@ -105,14 +105,32 @@ final class Constants {
 	static final int THEME_SYSTEM = 3;
 
 	/**
-	 * The {@link android.content.SharedPreferences} file name for this app.
+	 * The SharedPreferences file name for this app.
 	 */
 	static final String SHARED_PREF_FILE = "in.basulabs.mahalaya.SHARED_PREFERENCES";
 
 	/**
-	 * {@link android.content.SharedPreferences} key for the app theme.
+	 * SharedPreferences key for the app theme.
+	 * <p>
+	 * Can have one of the following values: {@link #THEME_LIGHT}, {@link #THEME_DARK}, {@link #THEME_AUTO_TIME} and
+	 * {@link #THEME_SYSTEM}.
+	 * </p>
 	 */
 	static final String SHARED_PREF_KEY_THEME = "in.basulabs.mahalaya.SHARED_PREF_THEME";
+
+	/**
+	 * SharedPreferences key indicating whether volume control is enabled or not. Type: boolean. Default: true.
+	 */
+	static final String SHARED_PREF_KEY_VOL_CTRL_ENABLED =	"in.basulabs.mahalaya.SHARED_PREF_VOL_CTRL_ENABLED";
+
+	/**
+	 * SharedPreferences key for the playback volume. Type: int.
+	 * <p>
+	 * Note that this is not the volume for the {@link android.media.MediaPlayer} (which will be either 1.0f or 0.2f
+	 * when ducked). This volume will be set as the volume for the media stream if volume control is enabled.
+	 * </p>
+	 */
+	static final String SHARED_PREF_KEY_VOLUME = "in.basulabs.mahalaya.SHARED_PREF_VOLUME";
 
 
 }

--- a/app/src/main/res/layout/countdown_activity_scroll_view.xml
+++ b/app/src/main/res/layout/countdown_activity_scroll_view.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -45,8 +44,8 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="20dp"
-        android:textStyle="normal"
         android:text="@string/ctda_default_date"
+        android:textStyle="normal"
         app:layout_constraintStart_toEndOf="@+id/dateViewLabel"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -68,8 +67,8 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="20dp"
-        android:textStyle="normal"
         android:text="@string/ctda_default_time"
+        android:textStyle="normal"
         app:layout_constraintStart_toEndOf="@+id/timeViewLabel"
         app:layout_constraintTop_toBottomOf="@+id/dateView" />
 
@@ -148,7 +147,7 @@
         android:layout_marginTop="10dp"
         android:layout_marginEnd="16dp"
         android:text="@string/vol_ctrl_check_box"
-        android:textSize="15sp"
+        android:textSize="17sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
@@ -156,26 +155,27 @@
 
     <TextView
         android:id="@+id/textView10"
+        style="@style/shortTextViewStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="20dp"
+        android:text="@string/vol_ctrl_label"
         android:textColor="@color/default_color"
         android:textStyle="bold"
-        style="@style/shortTextViewStyle"
-        android:text="@string/vol_ctrl_label"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider6" />
 
     <TextView
         android:id="@+id/playbackVolumeLabel"
+        style="@style/shortTextViewStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="20dp"
-        style="@style/shortTextViewStyle"
-        android:textStyle="normal"
         android:text="@string/set_volume_label"
+        android:textColor="@drawable/button_selection_colors"
+        android:textStyle="normal"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/volumeControlCheckBox" />
 

--- a/app/src/main/res/layout/countdown_activity_scroll_view.xml
+++ b/app/src/main/res/layout/countdown_activity_scroll_view.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -9,10 +10,9 @@
         style="@style/shortTextViewStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="30dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
         android:text="@string/ctda_time_left_label"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.046"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider5" />
 
@@ -21,12 +21,11 @@
         style="@style/buttonStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="30dp"
+        android:layout_marginTop="20dp"
         android:text="@string/ctda_abort_button"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.492"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider6" />
+        app:layout_constraintTop_toBottomOf="@+id/divider11" />
 
     <TextView
         android:id="@+id/dateViewLabel"
@@ -34,10 +33,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="40dp"
+        android:layout_marginTop="20dp"
         android:text="@string/ctda_date_label"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -46,12 +43,11 @@
         style="@style/shortTextViewStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
+        android:textStyle="normal"
         android:text="@string/ctda_default_date"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/dateViewLabel"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
@@ -60,10 +56,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="20dp"
         android:text="@string/ctda_time_label"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/dateViewLabel" />
 
@@ -72,12 +66,11 @@
         style="@style/shortTextViewStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
+        android:textStyle="normal"
         android:text="@string/ctda_default_time"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/timeViewLabel"
         app:layout_constraintTop_toBottomOf="@+id/dateView" />
 
     <TextView
@@ -86,7 +79,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="15dp"
         android:layout_marginEnd="16dp"
         android:text="@string/default_time_left"
         android:textStyle="normal"
@@ -113,7 +106,7 @@
         android:id="@+id/divider5"
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:layout_marginTop="30dp"
+        android:layout_marginTop="20dp"
         android:background="?android:attr/listDivider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -123,7 +116,7 @@
         android:id="@+id/divider6"
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:layout_marginTop="30dp"
+        android:layout_marginTop="20dp"
         android:background="?android:attr/listDivider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -133,7 +126,7 @@
         android:id="@+id/divider9"
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:layout_marginTop="25dp"
+        android:layout_marginTop="20dp"
         android:background="?android:attr/listDivider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -141,10 +134,73 @@
 
     <Space
         android:layout_width="wrap_content"
-        android:layout_height="20dp"
+        android:layout_height="10dp"
         android:layout_marginTop="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/reminder_vol" />
+
+    <CheckBox
+        android:id="@+id/volumeControlCheckBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/vol_ctrl_check_box"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView10" />
+
+    <TextView
+        android:id="@+id/textView10"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
+        android:textColor="@color/default_color"
+        android:textStyle="bold"
+        style="@style/shortTextViewStyle"
+        android:text="@string/vol_ctrl_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider6" />
+
+    <TextView
+        android:id="@+id/playbackVolumeLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
+        style="@style/shortTextViewStyle"
+        android:textStyle="normal"
+        android:text="@string/set_volume_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/volumeControlCheckBox" />
+
+    <SeekBar
+        android:id="@+id/playbackVolumeSeekBar"
+        style="@style/Widget.AppCompat.SeekBar.Discrete"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="16dp"
+        android:max="10"
+        android:progress="3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/playbackVolumeLabel" />
+
+    <View
+        android:id="@+id/divider11"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="20dp"
+        android:background="?android:attr/listDivider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/playbackVolumeSeekBar" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -136,4 +136,7 @@
         গেলে উপরের বোতামটি দিয়ে ফাইলটি নির্বাচন করুন। ফাইলটি এসডি কার্ড বা অভ্যন্তরীণ স্টোরেজে রাখা যেতে পারে।</string>
     <string name="default_time_left_notif">অপেক্ষা করুন…</string>
     <string name="request_focus_notif">অপেক্ষা করুন…</string>
+    <string name="vol_ctrl_label">ভলিউম নিয়ন্ত্রণ:</string>
+    <string name="vol_ctrl_check_box">এই অ্যাপ্লিকেশনটিকে মিডিয়া স্ট্রিমের ভলিউম পরিবর্তন করার অনুমতি দিন</string>
+    <string name="set_volume_label">প্লেব্যাক ভলিউম সেট করুন:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,10 @@
     <string name="ctda_default_time">00:00</string>
     <string name="default_time_left">Calculating…</string>
     <string name="ctda_abort_button">Abort program</string>
+    <string name="vol_ctrl_label">Volume controls:</string>
+    <string name="vol_ctrl_check_box">Allow this app to change media stream volume</string>
+    <string name="set_volume_label">Set playback volume:</string>
+    <string name="marquee_volume_reminder">Remember to set a decent media volume!</string>
 
     <!-- MahalayaService -->
     <string name="default_time_left_notif">Calculating time left…</string>
@@ -46,7 +50,6 @@
     <!-- MediaPlayerActivity -->
     <string name="mpa_default_media_state">Determining media state…</string>
     <string name="mpa_abort_button">Abort playing media</string>
-    <string name="marquee_volume_reminder">Remember to set a decent media volume!</string>
 
     <!-- ThankYouActivity -->
     <string name="morning">Good Morning!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,7 +39,6 @@
     <string name="default_time_left">Calculating…</string>
     <string name="ctda_abort_button">Abort program</string>
     <string name="vol_ctrl_label">Volume controls:</string>
-    <string name="vol_ctrl_check_box">Allow this app to change media stream volume</string>
     <string name="set_volume_label">Set playback volume:</string>
     <string name="marquee_volume_reminder">Remember to set a decent media volume!</string>
 
@@ -176,6 +175,7 @@
     <string name="mp3_download">Download media file in mp3 format</string>
 
     <string name="dont_have_file">Links to download the media file:</string>
+    <string name="vol_ctrl_check_box">Allow this app to change media stream volume</string>
 
 
 </resources>


### PR DESCRIPTION
An option has been added in `CountdownActivity` that allows the user to let the app set the media stream volume before playback. If enabled, the app will change the volume of the aforesaid stream before playback, and reinitialise it (to what it was before the playback started) after the playback is over.